### PR TITLE
Introduced a previous env for backward compatibility

### DIFF
--- a/minikube.yaml
+++ b/minikube.yaml
@@ -273,6 +273,9 @@ spec:
           env:
             - name: IO_TACKLE_WINDUP_REST_SHARED_FOLDER_PATH
               value: "/opt/windup/shared"
+              # available for backward compatibility but to be removed once the above image will be updated
+            - name: ORG_JBOSS_WINDUP_WEB_SHARED_FOLDER_PATH
+              value: "/opt/windup/shared"
             - name: QUARKUS_ARTEMIS_URL
               value: "tcp://artemis:61616"
             - name: QUARKUS_LOG_LEVEL

--- a/openshift/windup-api-with-tackle.yaml
+++ b/openshift/windup-api-with-tackle.yaml
@@ -290,6 +290,9 @@ objects:
               env:
                 - name: IO_TACKLE_WINDUP_REST_SHARED_FOLDER_PATH
                   value: "/opt/windup/shared"
+                  # available for backward compatibility but to be removed once the above image will be updated
+                - name: ORG_JBOSS_WINDUP_WEB_SHARED_FOLDER_PATH
+                  value: "/opt/windup/shared"
                 - name: QUARKUS_ARTEMIS_URL
                   value: "tcp://artemis:61616"
                 - name: QUARKUS_LOG_LEVEL

--- a/openshift/windup-api.yaml
+++ b/openshift/windup-api.yaml
@@ -289,6 +289,9 @@ objects:
               env:
                 - name: IO_TACKLE_WINDUP_REST_SHARED_FOLDER_PATH
                   value: "/opt/windup/shared"
+                  # available for backward compatibility but to be removed once the above image will be updated
+                - name: ORG_JBOSS_WINDUP_WEB_SHARED_FOLDER_PATH
+                  value: "/opt/windup/shared"
                 - name: QUARKUS_ARTEMIS_URL
                   value: "tcp://artemis:61616"
                 - name: QUARKUS_LOG_LEVEL

--- a/windup-api-with-tackle.yaml
+++ b/windup-api-with-tackle.yaml
@@ -3110,6 +3110,9 @@ spec:
           env:
             - name: IO_TACKLE_WINDUP_REST_SHARED_FOLDER_PATH
               value: "/opt/windup/shared"
+              # available for backward compatibility but to be removed once the above image will be updated
+            - name: ORG_JBOSS_WINDUP_WEB_SHARED_FOLDER_PATH
+              value: "/opt/windup/shared"
             - name: QUARKUS_ARTEMIS_URL
               value: "tcp://artemis:61616"
             - name: QUARKUS_LOG_LEVEL


### PR DESCRIPTION
Re-introduced the `ORG_JBOSS_WINDUP_WEB_SHARED_FOLDER_PATH` env variable that has been removed during the project migration into Konveyor because the `quay.io/windupeng/windup-api:0.0.1-SNAPSHOT` has not been updated yet to avoid issues to the users testing this right now.