### PR TITLE
WindupExecutionModel - Removed AnalysisModel adjacency

### DIFF
--- a/src/main/java/io/tackle/windup/rest/graph/model/WindupExecutionModel.java
+++ b/src/main/java/io/tackle/windup/rest/graph/model/WindupExecutionModel.java
@@ -16,7 +16,6 @@ public interface WindupExecutionModel extends WindupVertexFrame {
     String TYPE = "WindupExecutionModel";
     String WINDUP_EXECUTION_ID = "windupExecutionModelId";
     String VERSION = "version";
-    String BELONGS = "belongs";
     String USES = "uses";
     /**
      * not using "outputPath" to avoid clashing with {@link org.jboss.windup.graph.model.WindupConfigurationModel#OUTPUT_PATH WindupConfigurationModel.OUTPUT_PATH}
@@ -46,18 +45,6 @@ public interface WindupExecutionModel extends WindupVertexFrame {
 
     @Property(VERSION)
     void setVersion(int version);
-
-    /**
-     * Contains the analysis owning this execution
-     */
-    @Adjacency(label = BELONGS, direction = Direction.IN)
-    AnalysisModel getAnalysis();
-
-    /**
-     * Sets the analysis owning this
-     */
-    @Adjacency(label = BELONGS, direction = Direction.IN)
-    void setAnalysis(AnalysisModel analysis);
 
     @Adjacency(label = USES, direction = Direction.OUT)
     WindupConfigurationModel getConfiguration();

--- a/src/main/java/io/tackle/windup/rest/resources/WindupResource.java
+++ b/src/main/java/io/tackle/windup/rest/resources/WindupResource.java
@@ -289,7 +289,6 @@ public class WindupResource {
                     analysisRequest.packages,
                     analysisRequest.sourceMode);
             final WindupExecutionModel windupExecutionModel = graphService.createFromWindupExecution(windupExecution);
-            windupExecutionModel.setAnalysis(analysisModel);
             analysisModel.addWindupExecution(windupExecutionModel);
             graphService.getCentralGraphTraversalSource().tx().commit();
             windupBroadcasterResource.broadcastMessage(String.format("{\"id\":%s,\"state\":\"INIT\",\"currentTask\":\"Analysis waiting to be executed\",\"totalWork\":2,\"workCompleted\":2}", analysisModel.getAnalysisId()));


### PR DESCRIPTION
https://github.com/konveyor/tackle-windup-api/blob/a93b5823080adfafa28296045f5010fb65254407/src/main/java/io/tackle/windup/rest/graph/model/AnalysisModel.java#L23 will manage the edge between the models.