### PR TITLE
Moved to use latest 'ubi8' image to ensure security fixes

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/windup-api-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8


### PR DESCRIPTION
Since we're building from `ubi8` image, it means it's safe to use `latest` tag as it moves within minor versions as `ubi8` represents the major version.